### PR TITLE
Fix signed compare and other gcc compiler warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,14 @@ matrix:
       env:
         - C_COMPILER=gcc-7
         - CXX_COMPILER=g++-7
+        - CXX_FLAGS=-Werror=sign-compare
+
+      install:
+         - mkdir /tmp/build-gtest && cd /tmp/build-gtest
+         - cmake /usr/src/gtest
+         - make
+         - sudo cp libgtest* /usr/lib/
+         - cd -
 
     - os: linux
       dist: xenial
@@ -36,18 +44,71 @@ matrix:
       env:
         - C_COMPILER=gcc-8
         - CXX_COMPILER=g++-8
+        - CXX_FLAGS=-Werror=sign-compare
 
-install:
-   - mkdir /tmp/build-gtest && cd /tmp/build-gtest
-   - cmake /usr/src/gtest
-   - make
-   - sudo cp libgtest* /usr/lib/
-   - cd -
+      install:
+        - mkdir /tmp/build-gtest && cd /tmp/build-gtest
+        - cmake /usr/src/gtest
+        - make
+        - sudo cp libgtest* /usr/lib/
+        - cd -
    
+
+    - os: linux
+      dist: focal
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-9
+            - libgtest-dev
+            - googletest
+            - cmake
+
+      compiler: gcc-9
+
+      env:
+        - C_COMPILER=gcc-9
+        - CXX_COMPILER=g++-9
+        - CXX_FLAGS=-Werror=sign-compare
+
+      install:
+        - mkdir /tmp/build-gtest && cd /tmp/build-gtest
+        - cmake /usr/src/googletest
+        - sudo cmake --build . --target install
+        - cd -
+
+    - os: linux
+      dist: focal
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-10
+            - libgtest-dev
+            - googletest
+            - cmake
+
+      compiler: gcc-10
+
+      env:
+        - C_COMPILER=gcc-10
+        - CXX_COMPILER=g++-10
+        - CXX_FLAGS=-Werror=sign-compare
+
+      install:
+        - mkdir /tmp/build-gtest && cd /tmp/build-gtest
+        - cmake /usr/src/googletest
+        - sudo cmake --build . --target install
+        - cd -
+
 script:
   - >- 
      cmake -H. -Bbuild
      -DCMAKE_C_COMPILER=$C_COMPILER -DCMAKE_CXX_COMPILER=$CXX_COMPILER
+     -DCMAKE_CXX_FLAGS="$CXX_FLAGS"
      -DARGUMENTUM_BUILD_EXAMPLES=ON -DARGUMENTUM_BUILD_TESTS=ON
   - cd build
   - cmake --build .

--- a/src/argparser.h
+++ b/src/argparser.h
@@ -85,7 +85,7 @@ public:
    CommandConfig add_command( const std::string& name )
    {
       return params().add_command<TOptions>( name );
-   };
+   }
 
    // Deprecated. Use args = parser.params(); args.add_command(...);
    ARGUMENTUM_DEPRECATED( "Use parser.params()" )

--- a/src/convert.h
+++ b/src/convert.h
@@ -43,12 +43,14 @@ T parse_int( const std::string& s )
       return static_cast<T>( res );
    };
 
-   if ( std::numeric_limits<T>::is_signed )
+   if constexpr ( std::numeric_limits<T>::is_signed )
       return checkResult( sign * strtoll( sv.data(), &pend, base ) );
-   else if ( sign > 0 )
-      return checkResult( strtoull( sv.data(), &pend, base ) );
-   else
-      throw std::out_of_range( s );
+   else {
+      if ( sign > 0 )
+         return checkResult( strtoull( sv.data(), &pend, base ) );
+      else
+         throw std::out_of_range( s );
+   }
 }
 
 namespace strtodx {

--- a/test/help_t.cpp
+++ b/test/help_t.cpp
@@ -40,7 +40,6 @@ TEST( ArgumentParserHelpTest, shouldAcceptArgumentHelpStrings )
 TEST( ArgumentParserHelpTest, shouldSetProgramName )
 {
    auto parser = argument_parser{};
-   auto params = parser.params();
    parser.config().program( "testing-testing" );
 
    auto& config = parser.getConfig();
@@ -50,7 +49,6 @@ TEST( ArgumentParserHelpTest, shouldSetProgramName )
 TEST( ArgumentParserHelpTest, shouldSetProgramDescription )
 {
    auto parser = argument_parser{};
-   auto params = parser.params();
    parser.config().description( "An example." );
 
    auto& config = parser.getConfig();
@@ -60,7 +58,6 @@ TEST( ArgumentParserHelpTest, shouldSetProgramDescription )
 TEST( ArgumentParserHelpTest, shouldSetProgramUsage )
 {
    auto parser = argument_parser{};
-   auto params = parser.params();
    parser.config().usage( "example [options] [arguments]" );
 
    auto& config = parser.getConfig();
@@ -163,7 +160,6 @@ TEST( ArgumentParserHelpTest, shouldFormatDescriptionsToTheSameColumn )
 TEST( ArgumentParserHelpTest, shouldSetHelpEpilog )
 {
    auto parser = argument_parser{};
-   auto params = parser.params();
    parser.config().epilog( "This comes after help." );
 
    auto& config = parser.getConfig();
@@ -679,7 +675,6 @@ TEST( ArgumentParserHelpTest, shouldUseSamePositionalMetavarNameInUsageAndHelp )
 
    std::map<std::string, long> count{ { "xpos", 0 }, { "XPOS", 0 }, { "xmetapos", 0 },
       { "XMETAPOS", 0 }, { "mpos", 0 }, { "MPOS", 0 } };
-   int i = 0;
    for ( auto line : helpLines ) {
       for ( const auto& tag : count ) {
          if ( strHasText( line, tag.first ) )

--- a/test/value_t.cpp
+++ b/test/value_t.cpp
@@ -43,8 +43,9 @@ TEST( ValueTest, shouldAssignUniqueValueTypeId )
 
    for ( auto pv1 : all )
       for ( auto pv2 : all )
-         if ( pv1 != pv2 )
+         if ( pv1 != pv2 ) {
             EXPECT_TRUE( pv1->getValueTypeId() != pv2->getValueTypeId() );
+         }
 }
 
 TEST( ValueTest, shouldCastVoidValueToVoidValue )

--- a/test/vectors.h
+++ b/test/vectors.h
@@ -22,7 +22,7 @@ bool vector_eq( const std::vector<T>& values, const std::vector<T>& var )
       return false;
    }
 
-   for ( int i = 0; i < var.size(); ++i )
+   for ( unsigned i = 0; i < var.size(); ++i )
       if ( values[i] != var[i] ) {
          std::cout << "Value: '" << values[i] << "'!='" << var[i] << "'\n";
          dump();


### PR DESCRIPTION
This fixes issue #6 when signed/unsigned comparisons are treated as errors. 