### PR TITLE
Upgrade .metavar() so that different names can be used

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -14,7 +14,7 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: None
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-# TODO (clf9): AllowShortLambdasOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Empty
 AlwaysBreakAfterDefinitionReturnType: None
 AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ build/
 build-*/
 .vs/
 out/
-CMakeSettings.json
 
 *.swp
 *.*~

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,0 +1,28 @@
+﻿{
+  "configurations": [
+    {
+      "name": "win-x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "buildRoot": "${projectDir}\\out\\build\\${name}",
+      "installRoot": "${projectDir}\\out\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "variables": [
+        {
+          "name": "ARGUMENTUM_BUILD_TESTS",
+          "value": "True",
+          "type": "BOOL"
+        },
+        {
+          "name": "CMAKE_CXX_FLAGS",
+          "value": "/DWIN32 /D_WINDOWS /W4 /wd4100 /we4018 /GR /EHsc",
+          "type": "STRING"
+        }
+      ],
+      "cmakeToolchain": "D:/users/mmarko/vcpkg/scripts/buildsystems/vcpkg.cmake"
+    }
+  ]
+}

--- a/src/argdescriber.h
+++ b/src/argdescriber.h
@@ -25,7 +25,8 @@ public:
    ArgumentHelpResult describeCommand( const Command& command ) const;
 
 private:
-   std::string describeArguments( const Option& option, const std::string& metavar ) const;
+   std::string describeArguments(
+         const Option& option, const std::vector<std::string>& metavar ) const;
 };
 
 }   // namespace argumentum

--- a/src/argdescriber_impl.h
+++ b/src/argdescriber_impl.h
@@ -84,7 +84,7 @@ ARGUMENTUM_INLINE std::string ArgumentDescriber::describeArguments(
       const Option& option, const std::vector<std::string>& metavars ) const
 {
    std::string res;
-   auto getMetavar( [&]( int i ) {
+   auto getMetavar( [&]( unsigned i ) {
       if ( metavars.empty() )
          return option.getHelpName();
 
@@ -93,11 +93,11 @@ ARGUMENTUM_INLINE std::string ArgumentDescriber::describeArguments(
       return metavars[i];
    } );
 
-   int i = 0;
+   unsigned i = 0;
    auto [mmin, mmax] = option.getArgumentCounts();
    if ( mmin > 0 ) {
       res = getMetavar( 0 );
-      for ( i = 1; i < mmin; ++i )
+      for ( i = 1; i < unsigned( mmin ); ++i )
          res = res + " " + getMetavar( i );
    }
    if ( mmax < mmin ) {

--- a/src/argdescriber_impl.h
+++ b/src/argdescriber_impl.h
@@ -83,24 +83,32 @@ ARGUMENTUM_INLINE ArgumentHelpResult ArgumentDescriber::describeCommand(
 ARGUMENTUM_INLINE std::string ArgumentDescriber::describeArguments(
       const Option& option, const std::vector<std::string>& metavars ) const
 {
-   auto metavar = metavars.empty() ? "TODO" : metavars[0];
-
    std::string res;
+   auto getMetavar( [&]( int i ) {
+      if ( metavars.empty() )
+         return option.getHelpName();
+
+      if ( i >= metavars.size() )
+         return metavars.back();
+      return metavars[i];
+   } );
+
+   int i = 0;
    auto [mmin, mmax] = option.getArgumentCounts();
    if ( mmin > 0 ) {
-      res = metavar;
-      for ( int i = 1; i < mmin; ++i )
-         res = res + " " + metavar;
+      res = getMetavar( 0 );
+      for ( i = 1; i < mmin; ++i )
+         res = res + " " + getMetavar( i );
    }
    if ( mmax < mmin ) {
-      auto opt = ( res.empty() ? "[" : " [" ) + metavar + " ...]";
+      auto opt = ( res.empty() ? "[" : " [" ) + getMetavar( i ) + " ...]";
       res += opt;
    }
    else if ( mmax - mmin == 1 )
-      res += "[" + metavar + "]";
+      res += "[" + getMetavar( i ) + "]";
    else if ( mmax > mmin ) {
-      auto opt =
-            ( res.empty() ? "[" : " [" ) + metavar + " {0.." + std::to_string( mmax - mmin ) + "}]";
+      auto opt = ( res.empty() ? "[" : " [" ) + getMetavar( i ) + " {0.."
+            + std::to_string( mmax - mmin ) + "}]";
       res += opt;
    }
 

--- a/src/argdescriber_impl.h
+++ b/src/argdescriber_impl.h
@@ -101,6 +101,9 @@ ARGUMENTUM_INLINE std::string ArgumentDescriber::describeArguments(
 
    unsigned ivar = 0;
    auto [mmin, mmax] = option.getArgumentCounts();
+   if ( mmin < 0 )
+      mmin = 0;
+
    if ( mmin > 0 ) {
       // Mandatory parameters
       res = getMetavar( 0 );
@@ -120,12 +123,23 @@ ARGUMENTUM_INLINE std::string ArgumentDescriber::describeArguments(
    }
    else {
       // Optional parameters, limited
-      if ( mmax - mmin == 1 )
+      if ( mmax == 1 )
          res += getOpenBracket( res ) + getMetavar( ivar );
       else if ( mmax > mmin ) {
-         auto opt = getOpenBracket( res ) + getMetavar( ivar ) + " {0.."
-               + std::to_string( mmax - mmin ) + "}";
-         res += opt;
+         auto limit = std::min<size_t>( mmax - 1, metavars.size() - 1 );
+         while ( ivar < limit ) {
+            auto opt = getOpenBracket( res ) + getMetavar( ivar );
+            res += opt;
+            ++ivar;
+         }
+         auto remaining = mmax - limit;
+         if ( remaining == 1 )
+            res += getOpenBracket( res ) + getMetavar( ivar );
+         else {
+            auto opt = getOpenBracket( res ) + getMetavar( ivar ) + " {0.."
+                  + std::to_string( remaining ) + "}";
+            res += opt;
+         }
       }
    }
 

--- a/src/argdescriber_impl.h
+++ b/src/argdescriber_impl.h
@@ -81,8 +81,10 @@ ARGUMENTUM_INLINE ArgumentHelpResult ArgumentDescriber::describeCommand(
 }
 
 ARGUMENTUM_INLINE std::string ArgumentDescriber::describeArguments(
-      const Option& option, const std::string& metavar ) const
+      const Option& option, const std::vector<std::string>& metavars ) const
 {
+   auto metavar = metavars.empty() ? "TODO" : metavars[0];
+
    std::string res;
    auto [mmin, mmax] = option.getArgumentCounts();
    if ( mmin > 0 ) {

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -15,6 +15,7 @@ namespace argumentum {
 class Filesystem
 {
 public:
+   virtual ~Filesystem() = default;
    virtual std::unique_ptr<ArgumentStream> open( const std::string& filename ) = 0;
 };
 

--- a/src/iformathelp.h
+++ b/src/iformathelp.h
@@ -1,9 +1,10 @@
-// Copyright (c) 2018, 2019, 2020 Marko Mahnič
+// Copyright (c) 2018-2021 Marko Mahnič
 // License: MPL2. See LICENSE in the root of the project.
 
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace argumentum {
 
@@ -14,7 +15,7 @@ struct ArgumentHelpResult
    std::string help_name;
    std::string short_name;
    std::string long_name;
-   std::string metavar;
+   std::vector<std::string> metavar;
    std::string arguments;
    std::string help;
    bool isRequired = false;

--- a/src/option.h
+++ b/src/option.h
@@ -27,7 +27,7 @@ private:
    AssignDefaultAction mAssignDefaultAction;
    std::string mShortName;
    std::string mLongName;
-   std::string mMetavar;
+   std::vector<std::string> mMetavar;
    std::string mHelp;
    std::string mFlagValue = "1";
    std::vector<std::string> mChoices;
@@ -50,7 +50,7 @@ private:
 public:
    void setShortName( std::string_view name );
    void setLongName( std::string_view name );
-   void setMetavar( std::string_view varname );
+   void setMetavar( const std::vector<std::string_view>& varnames );
    void setHelp( std::string_view help );
    void setNArgs( int count );
    void setMinArgs( int count );
@@ -71,7 +71,7 @@ public:
    std::string getHelpName() const;
    bool hasName( std::string_view name ) const;
    const std::string& getRawHelp() const;
-   std::string getMetavar() const;
+   std::vector<std::string> getMetavar() const;
    void setValue( std::string_view value, Environment& env );
    void assignDefault();
    bool hasDefault() const;

--- a/src/option_impl.h
+++ b/src/option_impl.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2019, 2020 Marko Mahnič
+// Copyright (c) 2018-2021 Marko Mahnič
 // License: MPL2. See LICENSE in the root of the project.
 
 #pragma once
@@ -24,13 +24,28 @@ ARGUMENTUM_INLINE void Option::setLongName( std::string_view name )
 
 ARGUMENTUM_INLINE void Option::setMetavar( const std::vector<std::string_view>& varnames )
 {
-   auto cleanStr( []( std::string_view v ) -> std::string {
-      return std::string( v );
+   auto cleanVarName( []( std::string_view v ) -> std::string {
+      size_t b = 0;
+      size_t e = v.size();
+      while ( b < e && std::isspace( v[b] ) || v[b] == '-' )
+         ++b;
+      while ( b < e && std::isspace( v[e - 1] ) )
+         --e;
+
+      if ( b >= e )
+         return {};
+
+      std::string res;
+      res.reserve( e - b );
+      std::transform( v.begin() + b, v.begin() + e, std::back_inserter( res ), []( char c ) {
+         return std::isspace( c ) ? '_' : c;
+      } );
+      return res;
    } );
 
    mMetavar.clear();
-   for ( auto v : varnames ) {
-      auto cv = cleanStr( v );
+   for ( const auto& v : varnames ) {
+      auto cv = cleanVarName( v );
       if ( !cv.empty() )
          mMetavar.push_back( std::move( cv ) );
    }
@@ -132,6 +147,8 @@ ARGUMENTUM_INLINE const std::string& Option::getLongName() const
 ARGUMENTUM_INLINE std::string Option::getHelpName() const
 {
    if ( isPositional() ) {
+      // TODO: mMetavar should no longer be used as helpName since we do not
+      // know which name to choose.  Maybe help name should be set separately (.helpname).
       const auto& name =
             !mMetavar.empty() ? mMetavar[0] : ( !mLongName.empty() ? mLongName : mShortName );
       return !name.empty() ? name : "ARG";

--- a/src/optionconfig.h
+++ b/src/optionconfig.h
@@ -52,11 +52,23 @@ public:
       return *static_cast<this_t*>( this );
    }
 
+   // Define the name of the meta variable of the option that will be used as
+   // a placeholder for option values in the generated help.
+   //
+   // @p varname a string or a vector of strings.
+   this_t& metavar( std::string_view varname )
+   {
+      getOption().setMetavar( { varname } );
+      return *static_cast<this_t*>( this );
+   }
+
    // Define the names of the meta variables of the option that will be used as
    // a placeholder for option values in the generated help.
-   this_t& metavar( std::string_view varname... )
+   //
+   // @p varname a string or a vector of strings.
+   this_t& metavar( const std::vector<std::string_view>& varnames )
    {
-      getOption().setMetavar( varname );
+      getOption().setMetavar( varnames );
       return *static_cast<this_t*>( this );
    }
 

--- a/src/optionconfig.h
+++ b/src/optionconfig.h
@@ -52,9 +52,9 @@ public:
       return *static_cast<this_t*>( this );
    }
 
-   // Define the name of the meta variable of the option that will be used as a
-   // placeholder for option values in the generated help.
-   this_t& metavar( std::string_view varname )
+   // Define the names of the meta variables of the option that will be used as
+   // a placeholder for option values in the generated help.
+   this_t& metavar( std::string_view varname... )
    {
       getOption().setMetavar( varname );
       return *static_cast<this_t*>( this );

--- a/src/optionfactory.h
+++ b/src/optionfactory.h
@@ -45,9 +45,9 @@ public:
       else {
          using wrap_type = ConvertedValue<val_vector>;
          pValue = std::make_shared<wrap_type>( value );
-      }
 
-      return Option( getValueForKnownTarget( pValue ), Option::vectorValue );
+         return Option( getValueForKnownTarget( pValue ), Option::vectorValue );
+      }
    }
 
 private:

--- a/src/optionpack.h
+++ b/src/optionpack.h
@@ -15,6 +15,7 @@ class ParameterConfig;
 class Options
 {
 public:
+   virtual ~Options() = default;
    virtual void add_parameters( ParameterConfig& args )
    {
       // TODO (mmahnic): make method add_parameters( ParameterConfig) abstract.

--- a/src/parser_impl.h
+++ b/src/parser_impl.h
@@ -302,23 +302,13 @@ ARGUMENTUM_INLINE void Parser::closeOption()
 
 ARGUMENTUM_INLINE void Parser::addFreeArgument( std::string_view arg )
 {
-   if ( mPosition < mParserDef.mPositional.size() ) {
+   while ( mPosition < mParserDef.mPositional.size() ) {
       auto& option = *mParserDef.mPositional[mPosition];
       if ( option.willAcceptArgument() ) {
          setValue( option, arg );
          return;
       }
-      else {
-         ++mPosition;
-         while ( mPosition < mParserDef.mPositional.size() ) {
-            auto& option = *mParserDef.mPositional[mPosition];
-            if ( option.willAcceptArgument() ) {
-               setValue( option, arg );
-               return;
-            }
-            ++mPosition;
-         }
-      }
+      ++mPosition;
    }
 
    mResult.addIgnored( arg );

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable( argumentumTests
    forwardparam_t.cpp
    group_t.cpp
    help_t.cpp
+   metavar_t.cpp
    negativenumber_t.cpp
    number_t.cpp
    optionfactory_t.cpp

--- a/test/action_t.cpp
+++ b/test/action_t.cpp
@@ -167,7 +167,9 @@ TEST( ArgumentParserActionTest, shouldSetSameVariableThroughMultipleActions )
 
 TEST( ArgumentParserActionTest, shouldTerminateParserThroughEnvironmentInAction )
 {
-   auto actionNormal = []( std::string& target, const std::string& value ) { target = value; };
+   auto actionNormal = []( std::string& target, const std::string& value ) {
+      target = value;
+   };
    auto actionEnv = []( std::string& target, const std::string& value, Environment& env ) {
       target = value;
       env.exit_parser();

--- a/test/argparser_t.cpp
+++ b/test/argparser_t.cpp
@@ -492,10 +492,10 @@ TEST( ArgumentParserTest, shouldSupportMaxNumberOfOptionArguments )
    EXPECT_EQ( 0, res.errors.size() );
 
    for ( int nargs = 3; nargs < 5; ++nargs ) {
-      auto res = testWithMaxArgs( nargs, params );
+      auto res2 = testWithMaxArgs( nargs, params );
       EXPECT_TRUE( vector_eq( { "read", "the", "text" }, texts ) ) << "maxargs:" << nargs;
-      EXPECT_EQ( 0, res.ignoredArguments.size() ) << "maxargs:" << nargs;
-      EXPECT_EQ( 0, res.errors.size() ) << "maxargs:" << nargs;
+      EXPECT_EQ( 0, res2.ignoredArguments.size() ) << "maxargs:" << nargs;
+      EXPECT_EQ( 0, res2.errors.size() ) << "maxargs:" << nargs;
    }
 }
 
@@ -557,10 +557,10 @@ TEST( ArgumentParserTest, shouldSupportMaxNumberOfPositionalArguments )
    EXPECT_EQ( 0, res.errors.size() );
 
    for ( int nargs = 3; nargs < 5; ++nargs ) {
-      auto res = testWithMaxArgs( nargs, params );
+      auto res2 = testWithMaxArgs( nargs, params );
       EXPECT_TRUE( vector_eq( { "read", "the", "text" }, texts ) ) << "maxargs:" << nargs;
-      EXPECT_EQ( 0, res.ignoredArguments.size() ) << "maxargs:" << nargs;
-      EXPECT_EQ( 0, res.errors.size() ) << "maxargs:" << nargs;
+      EXPECT_EQ( 0, res2.ignoredArguments.size() ) << "maxargs:" << nargs;
+      EXPECT_EQ( 0, res2.errors.size() ) << "maxargs:" << nargs;
    }
 }
 

--- a/test/commandhelp_t.cpp
+++ b/test/commandhelp_t.cpp
@@ -56,7 +56,9 @@ struct TestCommandOptions : public argumentum::Options
 
    void add_parameters( ParameterConfig& params ) override
    {
-      auto pGlobal = std::make_shared<GlobalOptions>();
+      if ( !pGlobal )
+         pGlobal = std::make_shared<GlobalOptions>();
+
       params.add_parameters( pGlobal );
 
       params.add_command<CmdOneOptions>( "cmdone" ).help( "Command One description." );

--- a/test/help_t.cpp
+++ b/test/help_t.cpp
@@ -297,30 +297,6 @@ TEST( ArgumentParserHelpTest, shouldOutputOptionArguments )
    }
 }
 
-TEST( ArgumentParserHelpTest, shouldChangeOptionMetavarName )
-{
-   std::string str;
-   auto parser = argument_parser{};
-   auto params = parser.params();
-   params.add_parameter( str, "--bees" ).minargs( 1 ).metavar( "WORK" );
-
-   auto formatter = HelpFormatter();
-   formatter.setTextWidth( 60 );
-   formatter.setMaxDescriptionIndent( 20 );
-   auto help = getTestHelp( parser, formatter );
-   auto lines = splitLines( help, KEEPEMPTY );
-
-   for ( auto line : lines ) {
-      auto optpos = line.find( "--bees" );
-      if ( optpos == std::string::npos )
-         continue;
-
-      auto argspos = line.find( "WORK [WORK ...]" );
-      ASSERT_NE( std::string::npos, argspos );
-      EXPECT_LT( optpos, argspos );
-   }
-}
-
 TEST( ArgumentParserHelpTest, shouldDescribePositionalArguments )
 {
    std::string str;

--- a/test/help_t.cpp
+++ b/test/help_t.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2018, 2019, 2020 Marko Mahnič
+﻿// Copyright (c) 2018-2021 Marko Mahnič
 // License: MPL2. See LICENSE in the root of the project.
 
 #include "testutil.h"

--- a/test/metavar_t.cpp
+++ b/test/metavar_t.cpp
@@ -1,0 +1,61 @@
+// Copyright (c) 2018, 2019, 2020 Marko Mahnič
+// License: MPL2. See LICENSE in the root of the project.
+
+#include "testutil.h"
+
+#include <argumentum/argparse.h>
+
+#include <algorithm>
+#include <gtest/gtest.h>
+#include <sstream>
+
+using namespace argumentum;
+using namespace testutil;
+
+TEST( HelpMetavar, shouldChangeOptionMetavarName )
+{
+   std::string str;
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( str, "--bees" ).minargs( 1 ).metavar( "WORK" );
+
+   auto formatter = HelpFormatter();
+   formatter.setTextWidth( 60 );
+   formatter.setMaxDescriptionIndent( 20 );
+   auto help = getTestHelp( parser, formatter );
+   auto lines = splitLines( help, KEEPEMPTY );
+
+   for ( auto line : lines ) {
+      auto optpos = line.find( "--bees" );
+      if ( optpos == std::string::npos )
+         continue;
+
+      auto argspos = line.find( "WORK [WORK ...]" );
+      ASSERT_NE( std::string::npos, argspos );
+      EXPECT_LT( optpos, argspos );
+   }
+}
+
+TEST( HelpMetavar, shouldSupportMultipleMetavarsInOption )
+{
+   std::string str;
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( str, "--bees" ).nargs( 2 ).metavar( "FLY", "WORK" );
+
+   auto formatter = HelpFormatter();
+   formatter.setTextWidth( 60 );
+   formatter.setMaxDescriptionIndent( 20 );
+   auto help = getTestHelp( parser, formatter );
+   auto lines = splitLines( help, KEEPEMPTY );
+
+   for ( auto line : lines ) {
+      auto optpos = line.find( "--bees" );
+      if ( optpos == std::string::npos )
+         continue;
+
+      auto argspos = line.find( "FLY WORK" );
+      ASSERT_NE( std::string::npos, argspos );
+      EXPECT_LT( optpos, argspos );
+   }
+}

--- a/test/metavar_t.cpp
+++ b/test/metavar_t.cpp
@@ -133,3 +133,84 @@ TEST( HelpMetavar, shouldDisplayExcessiveMetavarsAsOptional )
       EXPECT_LT( optpos, argspos );
    }
 }
+
+TEST( HelpMetavar, shouldDisplayExcessiveMetavarsAsOptional_WithExactMax )
+{
+   std::string str;
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( str, "--bees" )
+         .minargs( 2 )
+         .maxargs( 5 )
+         .metavar( { "FLY", "WORK", "EAT", "DRINK", "SLEEP" } );
+
+   auto formatter = HelpFormatter();
+   formatter.setTextWidth( 60 );
+   formatter.setMaxDescriptionIndent( 20 );
+   auto help = getTestHelp( parser, formatter );
+   auto lines = splitLines( help, KEEPEMPTY );
+
+   for ( auto line : lines ) {
+      auto optpos = line.find( "--bees" );
+      if ( optpos == std::string::npos )
+         continue;
+
+      auto argspos = line.find( "FLY WORK [EAT [DRINK [SLEEP]]]" );
+      ASSERT_NE( std::string::npos, argspos );
+      EXPECT_LT( optpos, argspos );
+   }
+}
+
+TEST( HelpMetavar, shouldDisplayExcessiveMetavarsAsOptional_WithLowerMax )
+{
+   std::string str;
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( str, "--bees" )
+         .minargs( 2 )
+         .maxargs( 4 )
+         .metavar( { "FLY", "WORK", "EAT", "DRINK", "SLEEP" } );
+
+   auto formatter = HelpFormatter();
+   formatter.setTextWidth( 60 );
+   formatter.setMaxDescriptionIndent( 20 );
+   auto help = getTestHelp( parser, formatter );
+   auto lines = splitLines( help, KEEPEMPTY );
+
+   for ( auto line : lines ) {
+      auto optpos = line.find( "--bees" );
+      if ( optpos == std::string::npos )
+         continue;
+
+      auto argspos = line.find( "FLY WORK [EAT [DRINK]]" );
+      ASSERT_NE( std::string::npos, argspos );
+      EXPECT_LT( optpos, argspos );
+   }
+}
+
+TEST( HelpMetavar, shouldDisplayExcessiveMetavarsAsOptional_WithHigherMax )
+{
+   std::string str;
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( str, "--bees" )
+         .minargs( 2 )
+         .maxargs( 6 )
+         .metavar( { "FLY", "WORK", "EAT", "DRINK", "SLEEP" } );
+
+   auto formatter = HelpFormatter();
+   formatter.setTextWidth( 60 );
+   formatter.setMaxDescriptionIndent( 20 );
+   auto help = getTestHelp( parser, formatter );
+   auto lines = splitLines( help, KEEPEMPTY );
+
+   for ( auto line : lines ) {
+      auto optpos = line.find( "--bees" );
+      if ( optpos == std::string::npos )
+         continue;
+
+      auto argspos = line.find( "FLY WORK [EAT [DRINK [SLEEP{0-2}]]]" );
+      ASSERT_NE( std::string::npos, argspos );
+      EXPECT_LT( optpos, argspos );
+   }
+}

--- a/test/metavar_t.cpp
+++ b/test/metavar_t.cpp
@@ -19,7 +19,7 @@ std::optional<std::string> getMetavarHelpLine(
    std::string str;
    auto parser = argument_parser{};
    auto params = parser.params();
-   auto& bees = params.add_parameter( str, "--bees" ).metavar( metavarDef );
+   auto& bees = params.add_parameter( str, "--bees" ).metavar( metavarDef ).required( true );
    if ( minargs < maxargs )
       // only one of minargs, maxargs or nargs can be used
       bees.maxargs( maxargs );
@@ -117,7 +117,7 @@ TEST( HelpMetavar, shouldDisplayExcessiveMetavarsAsOptional_WithExactMax )
 
    ASSERT_TRUE( oLine.has_value() );
    auto argspos = oLine->find( "[FLY [WORK [EAT [DRINK [SLEEP]]]]]" );
-   ASSERT_NE( std::string::npos, argspos );
+   ASSERT_NE( std::string::npos, argspos ) << *oLine << "\n";
    EXPECT_LT( oLine->find( "--bees" ), argspos );
 }
 
@@ -128,7 +128,7 @@ TEST( HelpMetavar, shouldDisplayExcessiveMetavarsAsOptional_WithLowerMax )
 
    ASSERT_TRUE( oLine.has_value() );
    auto argspos = oLine->find( "[FLY [WORK [EAT [DRINK]]]]" );
-   ASSERT_NE( std::string::npos, argspos );
+   ASSERT_NE( std::string::npos, argspos ) << *oLine << "\n";
    EXPECT_LT( oLine->find( "--bees" ), argspos );
 }
 
@@ -139,7 +139,7 @@ TEST( HelpMetavar, shouldDisplayExcessiveMetavarsAsOptional_WithLowerMaxAtMinPlu
 
    ASSERT_TRUE( oLine.has_value() );
    auto argspos = oLine->find( "[FLY]" );
-   ASSERT_NE( std::string::npos, argspos );
+   ASSERT_NE( std::string::npos, argspos ) << *oLine << "\n";
    EXPECT_LT( oLine->find( "--bees" ), argspos );
 }
 
@@ -149,7 +149,7 @@ TEST( HelpMetavar, shouldDisplayExcessiveMetavarsAsOptional_WithHigherMax )
    auto oLine = getMetavarHelpLine( -1, 6, { "FLY", "WORK", "EAT", "DRINK", "SLEEP" } );
 
    ASSERT_TRUE( oLine.has_value() );
-   auto argspos = oLine->find( "[FLY [WORK [EAT [DRINK [SLEEP{0-2}]]]]]" );
-   ASSERT_NE( std::string::npos, argspos );
+   auto argspos = oLine->find( "[FLY [WORK [EAT [DRINK [SLEEP {0..2}]]]]]" );
+   ASSERT_NE( std::string::npos, argspos ) << *oLine << "\n";
    EXPECT_LT( oLine->find( "--bees" ), argspos );
 }

--- a/test/metavar_t.cpp
+++ b/test/metavar_t.cpp
@@ -59,3 +59,51 @@ TEST( HelpMetavar, shouldSupportMultipleMetavarsInOption )
       EXPECT_LT( optpos, argspos );
    }
 }
+
+TEST( HelpMetavar, shouldReuseTheLastMetavarInOption )
+{
+   std::string str;
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( str, "--bees" ).nargs( 5 ).metavar( { "FLY", "WORK" } );
+
+   auto formatter = HelpFormatter();
+   formatter.setTextWidth( 60 );
+   formatter.setMaxDescriptionIndent( 20 );
+   auto help = getTestHelp( parser, formatter );
+   auto lines = splitLines( help, KEEPEMPTY );
+
+   for ( auto line : lines ) {
+      auto optpos = line.find( "--bees" );
+      if ( optpos == std::string::npos )
+         continue;
+
+      auto argspos = line.find( "FLY WORK WORK WORK WORK" );
+      ASSERT_NE( std::string::npos, argspos );
+      EXPECT_LT( optpos, argspos );
+   }
+}
+
+TEST( HelpMetavar, shouldSupportReuseTheLastMetavarInOptionWithMinArgs )
+{
+   std::string str;
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( str, "--bees" ).minargs( 3 ).metavar( { "FLY", "WORK" } );
+
+   auto formatter = HelpFormatter();
+   formatter.setTextWidth( 60 );
+   formatter.setMaxDescriptionIndent( 20 );
+   auto help = getTestHelp( parser, formatter );
+   auto lines = splitLines( help, KEEPEMPTY );
+
+   for ( auto line : lines ) {
+      auto optpos = line.find( "--bees" );
+      if ( optpos == std::string::npos )
+         continue;
+
+      auto argspos = line.find( "FLY WORK WORK [WORK ...]" );
+      ASSERT_NE( std::string::npos, argspos );
+      EXPECT_LT( optpos, argspos );
+   }
+}

--- a/test/metavar_t.cpp
+++ b/test/metavar_t.cpp
@@ -84,7 +84,7 @@ TEST( HelpMetavar, shouldReuseTheLastMetavarInOption )
    }
 }
 
-TEST( HelpMetavar, shouldSupportReuseTheLastMetavarInOptionWithMinArgs )
+TEST( HelpMetavar, shouldReuseTheLastMetavarInOptionWithMinArgs )
 {
    std::string str;
    auto parser = argument_parser{};
@@ -103,6 +103,32 @@ TEST( HelpMetavar, shouldSupportReuseTheLastMetavarInOptionWithMinArgs )
          continue;
 
       auto argspos = line.find( "FLY WORK WORK [WORK ...]" );
+      ASSERT_NE( std::string::npos, argspos );
+      EXPECT_LT( optpos, argspos );
+   }
+}
+
+TEST( HelpMetavar, shouldDisplayExcessiveMetavarsAsOptional )
+{
+   std::string str;
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( str, "--bees" )
+         .minargs( 2 )
+         .metavar( { "FLY", "WORK", "EAT", "DRINK", "SLEEP" } );
+
+   auto formatter = HelpFormatter();
+   formatter.setTextWidth( 60 );
+   formatter.setMaxDescriptionIndent( 20 );
+   auto help = getTestHelp( parser, formatter );
+   auto lines = splitLines( help, KEEPEMPTY );
+
+   for ( auto line : lines ) {
+      auto optpos = line.find( "--bees" );
+      if ( optpos == std::string::npos )
+         continue;
+
+      auto argspos = line.find( "FLY WORK [EAT [DRINK [SLEEP ...]]]" );
       ASSERT_NE( std::string::npos, argspos );
       EXPECT_LT( optpos, argspos );
    }

--- a/test/metavar_t.cpp
+++ b/test/metavar_t.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, 2019, 2020 Marko Mahnič
+// Copyright (c) 2018-2021 Marko Mahnič
 // License: MPL2. See LICENSE in the root of the project.
 
 #include "testutil.h"
@@ -41,7 +41,7 @@ TEST( HelpMetavar, shouldSupportMultipleMetavarsInOption )
    std::string str;
    auto parser = argument_parser{};
    auto params = parser.params();
-   params.add_parameter( str, "--bees" ).nargs( 2 ).metavar( "FLY", "WORK" );
+   params.add_parameter( str, "--bees" ).nargs( 2 ).metavar( { "FLY", "WORK" } );
 
    auto formatter = HelpFormatter();
    formatter.setTextWidth( 60 );

--- a/test/optionfactory_t.cpp
+++ b/test/optionfactory_t.cpp
@@ -67,10 +67,10 @@ struct TestStructure
    int shared = 0;
    TestStructure() = default;
    TestStructure( const TestStructure& ) = default;
-   TestStructure( const std::string& v )
+   TestStructure( const std::string& )
    {}
    TestStructure& operator=( const TestStructure& ) = default;
-   TestStructure& operator=( const std::string& v )
+   TestStructure& operator=( const std::string& )
    {
       return *this;
    }

--- a/test/parserconfig_t.cpp
+++ b/test/parserconfig_t.cpp
@@ -55,5 +55,5 @@ TEST( ParserConfig, shouldChangeHelpFormatter )
    auto res = parser.parse_args( { "--help" } );
    EXPECT_FALSE( static_cast<bool>( res ) );
 
-   EXPECT_EQ( 1, pFormatter->formatCount );
+   EXPECT_EQ( 1U, pFormatter->formatCount );
 }

--- a/test/staticlib/basic_command_t.cpp
+++ b/test/staticlib/basic_command_t.cpp
@@ -46,8 +46,12 @@ protected:
       common = std::make_shared<SharedOptions>();
       params.add_parameters( common );
 
-      auto max = []( int a, int b ) { return std::max( a, b ); };
-      auto sum = []( int a, int b ) { return a + b; };
+      auto max = []( int a, int b ) {
+         return std::max( a, b );
+      };
+      auto sum = []( int a, int b ) {
+         return a + b;
+      };
 
       params.add_parameter( operation, "--sum", "-s" )
             .nargs( 0 )

--- a/test/value_t.cpp
+++ b/test/value_t.cpp
@@ -14,10 +14,10 @@ struct TestStructure
    int shared = 0;
    TestStructure() = default;
    TestStructure( const TestStructure& ) = default;
-   TestStructure( const std::string& v )
+   TestStructure( const std::string& )
    {}
    TestStructure& operator=( const TestStructure& ) = default;
-   TestStructure& operator=( const std::string& v )
+   TestStructure& operator=( const std::string& )
    {
       return *this;
    }


### PR DESCRIPTION
When an option takes multiple arguments, each argument can have a different name. An overload for .metavar() is added that accepts a vector of strings.

This change fixes issue #8.