### PR TITLE
Fix options with vector and optional<vector> targets 

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -43,3 +43,14 @@
 
 ## [Next]
 
+### Fixed
+
+- The optional<vector> targets are now filled correctly.
+
+### Changed
+
+- For options with vector targets the default count changed from `minagrs(0)` to `minargs(1)`.  For
+  options with `optional<vector>` targets the default is still `minargs(0)`.
+- When an option with a vector target has `minargs(0)` a flagValue is added to the vector only if
+  the vector is empty.
+

--- a/src/option.h
+++ b/src/option.h
@@ -5,6 +5,7 @@
 
 #include "value.h"
 
+#include <cassert>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -73,6 +74,11 @@ public:
    const std::string& getRawHelp() const;
    std::vector<std::string> getMetavar() const;
    void setValue( std::string_view value, Environment& env );
+
+   /**
+    * Called when an option was started but no values followed.
+    */
+   void autoSetMissingValue( Environment& env );
    void assignDefault();
    bool hasDefault() const;
    void resetValue();
@@ -101,8 +107,12 @@ private:
    Option( std::shared_ptr<Value>&& pValue, Kind kind )
       : mpValue( std::move( pValue ) )
       , mIsVectorValue( kind == Option::vectorValue )
-      , mMaxArgs( mIsVectorValue ? -1 : 0 )
-   {}
+      , mMinArgs(  kind == Option::vectorValue  ? 1 : 0 )
+      , mMaxArgs(  kind == Option::vectorValue  ? -1 : 0 )
+   {
+      // TODO: add getValue() that checks if it is nullptr and throws; returns *mpValue.
+      assert( mpValue != nullptr );
+   }
 };
 
 }   // namespace argumentum

--- a/src/option.h
+++ b/src/option.h
@@ -107,10 +107,7 @@ private:
    Option( std::shared_ptr<Value>&& pValue, Kind kind )
       : mpValue( std::move( pValue ) )
       , mIsVectorValue( kind == Option::vectorValue )
-      , mMinArgs(  kind == Option::vectorValue  ? 1 : 0 )
-      , mMaxArgs(  kind == Option::vectorValue  ? -1 : 0 )
    {
-      // TODO: add getValue() that checks if it is nullptr and throws; returns *mpValue.
       assert( mpValue != nullptr );
    }
 };

--- a/src/option.h
+++ b/src/option.h
@@ -101,6 +101,7 @@ private:
    Option( std::shared_ptr<Value>&& pValue, Kind kind )
       : mpValue( std::move( pValue ) )
       , mIsVectorValue( kind == Option::vectorValue )
+      , mMaxArgs( mIsVectorValue ? -1 : 0 )
    {}
 };
 

--- a/src/option_impl.h
+++ b/src/option_impl.h
@@ -198,6 +198,14 @@ ARGUMENTUM_INLINE void Option::setValue( std::string_view value, Environment& en
    mpValue->setValue( value, mAssignAction, env );
 }
 
+ARGUMENTUM_INLINE void Option::autoSetMissingValue( Environment& env )
+{
+   ++mCurrentAssignCount;
+   ++mTotalAssignCount;
+
+   mpValue->setMissingValue( getFlagValue(), env );
+}
+
 ARGUMENTUM_INLINE void Option::assignDefault()
 {
    if ( mAssignDefaultAction )

--- a/src/optionfactory.h
+++ b/src/optionfactory.h
@@ -46,7 +46,9 @@ public:
          using wrap_type = ConvertedValue<val_vector>;
          pValue = std::make_shared<wrap_type>( value );
 
-         return Option( getValueForKnownTarget( pValue ), Option::vectorValue );
+         auto option = Option( getValueForKnownTarget( pValue ), Option::vectorValue );
+         option.setMinArgs( 1 );
+         return option;
       }
    }
 
@@ -62,7 +64,9 @@ public:
          using wrap_type = ConvertedValue<val_vector>;
          pValue = std::make_shared<wrap_type>( value );
 
-         return Option( getValueForKnownTarget( pValue ), Option::vectorValue );
+         auto option = Option( getValueForKnownTarget( pValue ), Option::vectorValue );
+         option.setMinArgs( 0 );
+         return option;
       }
    }
 

--- a/src/optionfactory.h
+++ b/src/optionfactory.h
@@ -50,6 +50,22 @@ public:
       }
    }
 
+   template<typename TTarget>
+   Option createOption( std::optional<std::vector<TTarget>>& value )
+   {
+      std::shared_ptr<Value> pValue;
+      using val_vector = std::optional<std::vector<TTarget>>;
+      if constexpr ( std::is_base_of<Value, TTarget>::value ) {
+         throw UnsupportedTargetType( "Unsupported target type: optional<vector<Value>>." );
+      }
+      else {
+         using wrap_type = ConvertedValue<val_vector>;
+         pValue = std::make_shared<wrap_type>( value );
+
+         return Option( getValueForKnownTarget( pValue ), Option::vectorValue );
+      }
+   }
+
 private:
    std::shared_ptr<Value> getValueForKnownTarget( std::shared_ptr<Value> pValue )
    {

--- a/src/parser.h
+++ b/src/parser.h
@@ -41,6 +41,7 @@ private:
    void addFreeArgument( std::string_view arg );
    void addError( std::string_view optionName, int errorCode );
    void setValue( Option& option, std::string_view value );
+   void autoSetMissingValue( Option& option );
 
    void parse( ArgumentStream& argStream, unsigned depth );
    void parseCommandArguments(

--- a/src/parser_impl.h
+++ b/src/parser_impl.h
@@ -295,7 +295,7 @@ ARGUMENTUM_INLINE void Parser::closeOption()
       if ( option.needsMoreArguments() )
          addError( option.getHelpName(), MISSING_ARGUMENT );
       else if ( option.willAcceptArgument() && !option.wasAssignedThroughThisOption() )
-         setValue( option, option.getFlagValue() );
+         autoSetMissingValue( option );
    }
    mpActiveOption = nullptr;
 }
@@ -324,6 +324,23 @@ ARGUMENTUM_INLINE void Parser::setValue( Option& option, std::string_view value 
    try {
       auto env = Environment{ option, mResult, mParserDef };
       option.setValue( value, env );
+   }
+   catch ( const InvalidChoiceError& ) {
+      addError( option.getHelpName(), INVALID_CHOICE );
+   }
+   catch ( const std::invalid_argument& ) {
+      addError( option.getHelpName(), CONVERSION_ERROR );
+   }
+   catch ( const std::out_of_range& ) {
+      addError( option.getHelpName(), CONVERSION_ERROR );
+   }
+}
+
+ARGUMENTUM_INLINE void Parser::autoSetMissingValue( Option& option )
+{
+   try {
+      auto env = Environment{ option, mResult, mParserDef };
+      option.autoSetMissingValue( env );
    }
    catch ( const InvalidChoiceError& ) {
       addError( option.getHelpName(), INVALID_CHOICE );

--- a/src/value.h
+++ b/src/value.h
@@ -47,6 +47,10 @@ public:
    void setDefault( AssignDefaultAction action );
    /**
     * Called when an option expects 0 or more values, but none is given.
+    *
+    * Added to handle special cases for vectors and optional vectors.
+    * - vector: add flagValue if empty.
+    * - optional<vector>: set to empty vector if nullopt.
     */
    void setMissingValue( std::string_view flagValue, Environment& env );
    void markBadArgument();
@@ -165,12 +169,6 @@ protected:
       };
    }
 
-
-   // Special handling for vectors and optional vectors. Maybe also for optional
-   // strings.
-   // vector: add flagValue if empty
-   // optional<vector>: set to empty vector if nullopt
-   // string: set to empty string if nullopt
    AssignAction getMissingValueAction() override
    {
       return []( Value& value, const std::string& argument, Environment& ) {

--- a/src/value.h
+++ b/src/value.h
@@ -173,6 +173,17 @@ protected:
    }
 
    template<typename TVar>
+   void assign( std::optional<std::vector<TVar>>& var, const std::string& value )
+   {
+      TVar target;
+      assign( target, value );
+      if ( !var.has_value() )
+         var = std::vector<TVar>{};
+      var->emplace_back( std::move( target ) );
+
+   }
+
+   template<typename TVar>
    void assign( std::optional<TVar>& var, const std::string& value )
    {
       TVar target;

--- a/src/value.h
+++ b/src/value.h
@@ -233,7 +233,7 @@ protected:
    void assignMissing( std::optional<TVar>& var, const std::string& value )
    {
       if ( !var.has_value() )
-         var =TVar{};
+         var = TVar{};
    }
 
    template<typename TVar, std::enable_if_t<has_from_string<TVar>::value, int> = 0>

--- a/src/value_impl.h
+++ b/src/value_impl.h
@@ -38,6 +38,15 @@ ARGUMENTUM_INLINE void Value::setDefault( AssignDefaultAction action )
    }
 }
 
+ARGUMENTUM_INLINE void Value::setMissingValue( std::string_view flagValue, Environment& env )
+{
+   auto action = getMissingValueAction();
+   if ( action ) {
+      ++mAssignCount;
+      action( *this, "", env );
+   }
+}
+
 ARGUMENTUM_INLINE void Value::markBadArgument()
 {
    // Increase the assign count so that flagValue will not be used.
@@ -76,6 +85,11 @@ ARGUMENTUM_INLINE VoidValue* VoidValue::value_cast( Value& value )
 }
 
 ARGUMENTUM_INLINE AssignAction VoidValue::getDefaultAction()
+{
+   return {};
+}
+
+ARGUMENTUM_INLINE AssignAction VoidValue::getMissingValueAction()
 {
    return {};
 }

--- a/src/value_impl.h
+++ b/src/value_impl.h
@@ -43,7 +43,8 @@ ARGUMENTUM_INLINE void Value::setMissingValue( std::string_view flagValue, Envir
    auto action = getMissingValueAction();
    if ( action ) {
       ++mAssignCount;
-      action( *this, "", env );
+      std::string fv{ flagValue };
+      action( *this, fv, env );
    }
 }
 

--- a/test/action_t.cpp
+++ b/test/action_t.cpp
@@ -201,7 +201,7 @@ TEST( ArgumentParserActionTest, shouldThrowWhenExitRequestIsUnchecked )
 
    bool caught = false;
    try {
-      auto res = parser.parse_args( { "-x" } );
+      auto res = parser.parse_args( { "-x", "1" } );
    }
    catch ( const argumentum::UncheckedParseResult& ) {
       caught = true;

--- a/test/argparser_t.cpp
+++ b/test/argparser_t.cpp
@@ -602,9 +602,9 @@ TEST( ArgumentParserTest, shouldLoadOptionValuesIntoOptionalVector )
    auto params = parser.params();
    params.add_parameter( texts, "-v" );
 
-   auto res = parser.parse_args( { "-v", "1", "2" } );
+   auto res = parser.parse_args( { "-v", "a", "b" } );
    ASSERT_TRUE( texts.has_value() );
-   EXPECT_TRUE( vector_eq( { "1", "2" }, *texts ) );
+   EXPECT_TRUE( vector_eq( { "a", "b" }, *texts ) );
 }
 
 TEST( ArgumentParserTest, shouldFillOptionalOfOptionalVectorForOptionWitoutValues )

--- a/test/argparser_t.cpp
+++ b/test/argparser_t.cpp
@@ -607,7 +607,7 @@ TEST( ArgumentParserTest, shouldLoadOptionValuesIntoOptionalVector )
    EXPECT_TRUE( vector_eq( { "a", "b" }, *texts ) );
 }
 
-TEST( ArgumentParserTest, shouldFillOptionalOfOptionalVectorForOptionWitoutValues )
+TEST( ArgumentParserTest, shouldFillOptionalOfOptionalVectorForOptionWithoutValues )
 {
    std::optional<std::vector<std::string>> texts;
 

--- a/test/argparser_t.cpp
+++ b/test/argparser_t.cpp
@@ -613,7 +613,8 @@ TEST( ArgumentParserTest, shouldFillOptionalOfOptionalVectorForOptionWithoutValu
 
    auto parser = argument_parser{};
    auto params = parser.params();
-   params.add_parameter( texts, "-v" ).minargs(0);
+   // default for optional<vector> target is minargs(0)
+   params.add_parameter( texts, "-v" );
 
    auto res = parser.parse_args( { "-v" } );
    ASSERT_TRUE( texts.has_value() );
@@ -626,6 +627,7 @@ TEST( ArgumentParserTest, shouldFailForPlainVectorWithOptionWitoutValues )
 
    auto parser = argument_parser{};
    auto params = parser.params();
+   // default for vector target is minargs(1)
    params.add_parameter( texts, "-v" );
 
    auto res = parser.parse_args( { "-v" } );
@@ -633,12 +635,13 @@ TEST( ArgumentParserTest, shouldFailForPlainVectorWithOptionWitoutValues )
    ASSERT_FALSE( res.errors.empty() );
 }
 
-TEST( ArgumentParserTest, shouldAddMissingValueAtMostOnce )
+TEST( ArgumentParserTest, shouldAddMissingValueToPlainVectorAtMostOnce )
 {
    std::vector<std::string> texts;
 
    auto parser = argument_parser{};
    auto params = parser.params();
+   // default for vector target is minargs(1)
    params.add_parameter( texts, "-v" ).minargs(0);
 
    auto res = parser.parse_args( { "-v", "-v", "-v" } );
@@ -652,7 +655,7 @@ TEST( ArgumentParserTest, shouldNotAddValueToOptionalWhenMissingSetMoreThanOnce 
 
    auto parser = argument_parser{};
    auto params = parser.params();
-   params.add_parameter( texts, "-v" ).minargs(0);
+   params.add_parameter( texts, "-v" );
 
    auto res = parser.parse_args( { "-v", "-v", "-v" } );
    ASSERT_TRUE( bool( res ) );

--- a/test/argparser_t.cpp
+++ b/test/argparser_t.cpp
@@ -580,20 +580,6 @@ TEST( ArgumentParserTest, shouldSupportMaxNumberOfPositionalArguments )
    }
 }
 
-// TODO: Add support for optional<vector>
-// Support for optional<vector> was requested in Gitub issue #17. This is
-// reasonable for options since we are now adding the value "1" when only an
-// option is present in args but has no values. The new solution would fill the
-// optional with an empty vector, but leave a bare vector intact.  This will
-// introduce a breaking change.
-//
-// Having an optional vector for positional argumetns does not make much sense
-// sicne if there is a value present, it will fill the optional and add the
-// value to the vector. But we can implement it anyway.
-//
-// Defaults:
-//      optional<vector>: minargs(0)
-//      vector: minargs(1)
 TEST( ArgumentParserTest, shouldLoadOptionValuesIntoOptionalVector )
 {
    std::optional<std::vector<std::string>> texts;

--- a/test/argparser_t.cpp
+++ b/test/argparser_t.cpp
@@ -580,6 +580,58 @@ TEST( ArgumentParserTest, shouldSupportMaxNumberOfPositionalArguments )
    }
 }
 
+// TODO: Add support for optional<vector>
+// Support for optional<vector> was requested in Gitub issue #17. This is
+// reasonable for options since we are now adding the value "1" when only an
+// option is present in args but has no values. The new solution would fill the
+// optional with an empty vector, but leave a bare vector intact.  This will
+// introduce a breaking change.
+//
+// Having an optional vector for positional argumetns does not make much sense
+// sicne if there is a value present, it will fill the optional and add the
+// value to the vector. But we can implement it anyway.
+//
+// Defaults:
+//      optional<vector>: minargs(0)
+//      vector: minargs(1)
+TEST( ArgumentParserTest, shouldLoadOptionValuesIntoOptionalVector )
+{
+   std::optional<std::vector<std::string>> texts;
+
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( texts, "-v" );
+
+   auto res = parser.parse_args( { "-v", "1", "2" } );
+   ASSERT_TRUE( texts.has_value() );
+   EXPECT_TRUE( vector_eq( { "1", "2" }, *texts ) );
+}
+
+TEST( ArgumentParserTest, shouldFillOptionalOfOptionalVectorForOptionWitoutValues )
+{
+   std::optional<std::vector<std::string>> texts;
+
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( texts, "-v" );
+
+   auto res = parser.parse_args( { "-v" } );
+   ASSERT_TRUE( texts.has_value() );
+   EXPECT_TRUE( texts->empty() );
+}
+
+TEST( ArgumentParserTest, shouldFailForPlainVectorWithOptionWitoutValues )
+{
+   std::vector<std::string> texts;
+
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( texts, "-v" );
+
+   auto res = parser.parse_args( { "-v" } );
+   ASSERT_FALSE( res.errors.empty() );
+}
+
 TEST( ArgumentParserTest, shouldSetDefaultCountForPositionalArgumentsWithVectorValues )
 {
    std::vector<std::string> texts;
@@ -612,6 +664,8 @@ TEST( ArgumentParserTest, shouldSetDefaultCountForPositionalArgumentsWithScalarV
    EXPECT_EQ( 0, res.errors.size() );
 }
 
+// TODO: breaking change: do not set the flag, use optional<vector> if flag
+// without elements is valid.
 TEST( ArgumentParserTest, shouldSetFlagValueWhenZeroOrMoreArgumentsRequiredAndNoneGiven )
 {
    std::vector<std::string> texts;

--- a/test/argparser_t.cpp
+++ b/test/argparser_t.cpp
@@ -633,6 +633,33 @@ TEST( ArgumentParserTest, shouldFailForPlainVectorWithOptionWitoutValues )
    ASSERT_FALSE( res.errors.empty() );
 }
 
+TEST( ArgumentParserTest, shouldAddMissingValueAtMostOnce )
+{
+   std::vector<std::string> texts;
+
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( texts, "-v" ).minargs(0);
+
+   auto res = parser.parse_args( { "-v", "-v", "-v" } );
+   ASSERT_TRUE( bool( res ) );
+   ASSERT_TRUE( vector_eq( { "1" }, texts ) );
+}
+
+TEST( ArgumentParserTest, shouldNotAddValueToOptionalWhenMissingSetMoreThanOnce )
+{
+   std::optional<std::vector<std::string>> texts;
+
+   auto parser = argument_parser{};
+   auto params = parser.params();
+   params.add_parameter( texts, "-v" ).minargs(0);
+
+   auto res = parser.parse_args( { "-v", "-v", "-v" } );
+   ASSERT_TRUE( bool( res ) );
+   ASSERT_TRUE( texts.has_value() );
+   ASSERT_TRUE( texts->empty() );
+}
+
 TEST( ArgumentParserTest, shouldSetDefaultCountForPositionalArgumentsWithVectorValues )
 {
    std::vector<std::string> texts;

--- a/test/argparser_t.cpp
+++ b/test/argparser_t.cpp
@@ -613,7 +613,7 @@ TEST( ArgumentParserTest, shouldFillOptionalOfOptionalVectorForOptionWithoutValu
 
    auto parser = argument_parser{};
    auto params = parser.params();
-   params.add_parameter( texts, "-v" );
+   params.add_parameter( texts, "-v" ).minargs(0);
 
    auto res = parser.parse_args( { "-v" } );
    ASSERT_TRUE( texts.has_value() );
@@ -629,6 +629,7 @@ TEST( ArgumentParserTest, shouldFailForPlainVectorWithOptionWitoutValues )
    params.add_parameter( texts, "-v" );
 
    auto res = parser.parse_args( { "-v" } );
+   ASSERT_FALSE( bool( res ) );
    ASSERT_FALSE( res.errors.empty() );
 }
 


### PR DESCRIPTION
Fix problems reported in issue #17.

### Fixed

- The optional<vector> targets are now filled correctly.

### Changed

- For options with vector targets the default count changed from `minagrs(0)` to `minargs(1)`.  For
  options with `optional<vector>` targets the default is still `minargs(0)`.
- When an option with a vector target has `minargs(0)` a flagValue is added to the vector only if
  the vector is empty.
